### PR TITLE
fix constantize method

### DIFF
--- a/lib/devise.rb
+++ b/lib/devise.rb
@@ -313,7 +313,7 @@ module Devise
     end
 
     def get
-      ActiveSupport::Dependencies.constantize(@name)
+      @name.constantize
     end
   end
 


### PR DESCRIPTION
Fix:
Error in lib/devise.rb:316:in get: undefined method constantize for ActiveSupport::Dependencies:Module (NoMethodError)

